### PR TITLE
function Str::pad()  the second params must be int

### DIFF
--- a/src/Advanced/Formatter/Title.php
+++ b/src/Advanced/Formatter/Title.php
@@ -48,9 +48,9 @@ class Title extends MessageFormatter
         if ($tLength >= $width) {
             $titleIndent = Str::pad(self::CHAR_SPACE, $indent, self::CHAR_SPACE);
         } elseif ($opts['titlePos'] === self::POS_RIGHT) {
-            $titleIndent = Str::pad(self::CHAR_SPACE, ceil($width - $tLength) + $indent, self::CHAR_SPACE);
+            $titleIndent = Str::pad(self::CHAR_SPACE, (int)ceil($width - $tLength) + $indent, self::CHAR_SPACE);
         } elseif ($opts['titlePos'] === self::POS_MIDDLE) {
-            $titleIndent = Str::pad(self::CHAR_SPACE, ceil(($width - $tLength) / 2) + $indent, self::CHAR_SPACE);
+            $titleIndent = Str::pad(self::CHAR_SPACE, (int)ceil(($width - $tLength) / 2) + $indent, self::CHAR_SPACE);
         } elseif ($indent > 0){
             $titleIndent = Str::pad(self::CHAR_SPACE, $indent, self::CHAR_SPACE);
         }


### PR DESCRIPTION
Argument 2 passed to Swoft\Stdlib\Helper\StringHelper::pad() must be of the type integer, float given, called in /www/wwwroot/swoft/api/vendor/swoft/console/src/Advanced/Formatter/Title.php on line 55 /www/wwwroot/swoft/api/vendor/swoft/stdlib/src/Helper/StringHelper.php 233